### PR TITLE
OA-55 Implement a Prometheus Exporter Proxy (similar to the exporter_exporter)

### DIFF
--- a/checkrunner/prometheuscheck.go
+++ b/checkrunner/prometheuscheck.go
@@ -1,0 +1,103 @@
+package checkrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/it-novum/openitcockpit-agent-go/config"
+	log "github.com/sirupsen/logrus"
+)
+
+type PrometheusCheckExecutor struct {
+	Configuration *config.PrometheusExporter
+	ResultOutput  chan *PrometheusExporterResult
+
+	wg       sync.WaitGroup
+	shutdown chan struct{}
+}
+
+func (c *PrometheusCheckExecutor) Shutdown() {
+	close(c.shutdown)
+	c.wg.Wait()
+}
+
+func (c *PrometheusCheckExecutor) runCheck(ctx context.Context, timeout time.Duration) {
+	log.Debugln("Begin Prometheus Exporter: ", c.Configuration.Name)
+
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	url := fmt.Sprintf("http://%s:%d%s", "localhost", c.Configuration.Port, c.Configuration.Path)
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Infoln("Prometheus Exporter '", c.Configuration.Name, "' error: ", err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Infoln("Prometheus Exporter Error reading response body '", c.Configuration.Name, "' error: ", err)
+		return
+	}
+
+	select {
+	// Return custom check result to Agent Instance
+	case c.ResultOutput <- &PrometheusExporterResult{
+		Name:   c.Configuration.Name,
+		Result: string(body),
+	}:
+	case <-time.After(time.Second * 5):
+		log.Errorln("Internal error: timeout could not save Prometheus Exporter result")
+	case <-c.shutdown:
+		log.Errorln("Prometheus Exporte: canceled")
+		return
+	case <-ctx.Done():
+		log.Errorln("Prometheus Exporte: canceled")
+		return
+	}
+	log.Debugln("Finish Prometheus Exporte: ", c.Configuration.Name)
+}
+
+func (c *PrometheusCheckExecutor) Start(parent context.Context) error {
+	c.shutdown = make(chan struct{})
+	timeout := time.Duration(c.Configuration.Timeout) * time.Second
+	interval := time.Duration(c.Configuration.Interval) * time.Second
+
+	if timeout > interval {
+		return errors.New("custom check timeout must be lower or equal to interval")
+	}
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+
+		ctx, cancel := context.WithCancel(parent)
+		defer cancel()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		c.runCheck(ctx, timeout)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-c.shutdown:
+				if !ok {
+					return
+				}
+			case <-ticker.C:
+				c.runCheck(ctx, timeout)
+			}
+		}
+	}()
+
+	return nil
+}

--- a/checkrunner/prometheuscheckhandler.go
+++ b/checkrunner/prometheuscheckhandler.go
@@ -1,0 +1,101 @@
+package checkrunner
+
+import (
+	"context"
+	"sync"
+
+	"github.com/it-novum/openitcockpit-agent-go/config"
+	log "github.com/sirupsen/logrus"
+)
+
+type PrometheusExporterResult struct {
+	Name   string
+	Result string
+}
+
+// PrometheusCheckHandler runs proemtheus exporter
+type PrometheusCheckHandler struct {
+	// ResultOutput channel for check results
+	// Do not close before Shutdown completes
+	ResultOutput  chan *PrometheusExporterResult
+	Configuration []*config.PrometheusExporter
+
+	executors []*PrometheusCheckExecutor
+	shutdown  chan struct{}
+	wg        sync.WaitGroup
+}
+
+// stop all custom check executors in parallel
+// the cancel of the context should cause all executors to stop almost immediatly
+func (c *PrometheusCheckHandler) stopExecutors() {
+	if len(c.executors) < 1 {
+		return
+	}
+
+	stopC := make(chan *PrometheusCheckExecutor)
+
+	for i := 0; i < len(c.executors); i++ {
+		go func() {
+			for e := range stopC {
+				e.Shutdown()
+				log.Infoln("Prometheus Exporter ", e.Configuration.Name, " stopped")
+				c.wg.Done()
+			}
+		}()
+	}
+
+	for _, executor := range c.executors {
+		stopC <- executor
+	}
+
+	close(stopC)
+}
+
+// Run the custom checks in background (DO NOT RUN IN GO ROUTINE)
+func (c *PrometheusCheckHandler) Start(parentCtx context.Context) {
+	c.shutdown = make(chan struct{})
+	c.executors = make([]*PrometheusCheckExecutor, len(c.Configuration))
+
+	for i, checkConfig := range c.Configuration {
+		c.executors[i] = &PrometheusCheckExecutor{
+			Configuration: checkConfig,
+			ResultOutput:  c.ResultOutput,
+		}
+	}
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+
+		ctx, cancel := context.WithCancel(parentCtx)
+		defer cancel()
+
+		for _, executor := range c.executors {
+			log.Infoln("Custom Check ", executor.Configuration.Name, " starting")
+			c.wg.Add(1)
+			if err := executor.Start(ctx); err != nil {
+				log.Errorln(err)
+			}
+		}
+
+		defer c.stopExecutors()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-c.shutdown:
+				if !ok {
+					return
+				}
+			}
+		}
+
+	}()
+}
+
+// Shutdown custom check runner, waits for completion
+func (c *PrometheusCheckHandler) Shutdown() {
+	close(c.shutdown)
+	c.wg.Wait()
+}

--- a/example/config_example.ini
+++ b/example/config_example.ini
@@ -185,3 +185,28 @@ apikey =
 # Leave blank to not use a proxy server
 # Example: http://10.10.1.10:3128
 #proxy = http://10.10.1.10:3128
+
+
+#########################
+#  Prometheus Exporter  #
+#########################
+
+# The openITCOCKPIT Monitoring Agent can act as a Prometheus Exporter proxy.
+# This means that the Agent will scrape the metrics from the exporters defined in the prometheus_exporters.ini
+# and will expose them on the /prometheus endpoint.
+# The openITCOCKPIT Agent will not touch the metrics itself.
+# If the Agent is configured to use TLS encryption the /prometheus endpoint will also be encrypted.
+
+[prometheus]
+
+# Determines if the openITCOCKPIT Agent should act as a Prometheus Exporter
+enabled = True
+
+# List of Prometheus Exporters
+#
+# Leave blank for the default value
+#
+# Linux: /etc/openitcockpit-agent/prometheus_exporters.ini
+# Windows: C:\Program Files\it-novum\openitcockpit-agent\prometheus_exporters.ini
+# macOS: /Applications/openitcockpit-agent/prometheus_exporters.ini
+exporters = ./prometheus_exporters.ini

--- a/example/prometheus_exporters_example.ini
+++ b/example/prometheus_exporters_example.ini
@@ -1,0 +1,16 @@
+[node_exporter]
+enabled = True
+method = http
+port = 9100
+path = /metrics
+interval = 15
+timeout = 5
+
+[mysqld_exporter]
+enabled = True
+method = http
+port = 9104
+path = /metrics
+interval = 15
+timeout = 5
+

--- a/prometheus_exporters.ini
+++ b/prometheus_exporters.ini
@@ -1,0 +1,24 @@
+[node_exporter]
+enabled = True
+method = http
+port = 9100
+path = /metrics
+interval = 15
+timeout = 5
+
+[mysqld_exporter]
+enabled = True
+method = http
+port = 9104
+path = /metrics
+interval = 15
+timeout = 5
+
+
+[windows_exporter]
+enabled = False
+method = http
+port = 1337
+path = /metrics
+interval = 15
+timeout = 5

--- a/webserver/server.go
+++ b/webserver/server.go
@@ -42,8 +42,9 @@ type reloadConfig struct {
 
 // Server handling for http, should be created by New
 type Server struct {
-	StateInput <-chan []byte
-	Reloader   Reloader
+	StateInput      <-chan []byte
+	PrometheusInput <-chan map[string]string
+	Reloader        Reloader
 
 	reload   chan *reloadConfig
 	shutdown chan struct{}
@@ -77,9 +78,10 @@ func isAutosslEnabled(cfg *config.Configuration) bool {
 func (s *Server) doReload(ctx context.Context, cfg *reloadConfig) {
 	log.Infoln("Webserver: Reload")
 	newHandler := &handler{
-		StateInput:    s.StateInput,
-		Configuration: cfg.Configuration,
-		Reloader:      s.Reloader,
+		StateInput:      s.StateInput,
+		PrometheusInput: s.PrometheusInput,
+		Configuration:   cfg.Configuration,
+		Reloader:        s.Reloader,
 	}
 	newHandler.Start(ctx)
 	serverAddr := fmt.Sprintf("%s:%d", cfg.Configuration.Address, cfg.Configuration.Port)


### PR DESCRIPTION
This feature lets the openITCOCKPIT Agent act as a proxy for Prometheus Exporters installed on the same system.
The idea is to have one central HTTP endpoint that can be queried by openITCOCKPIT (the Agent itself) and a `/prometheus` target that can be scraped by Prometheus.

Exporters like for example the `node_exporter` do not have to be exposed to the network, instead they can be bind to `127.0.0.1` because the openITCOCKPIT Agent will scrape the exporters.

The new API endpoint `/prometheus` will return a list of all available exporters
![Unbenannt](https://github.com/it-novum/openitcockpit-agent-go/assets/9019992/a6aa3a05-4e12-4712-8a2e-c37620fc279b)


To get the data of a specific exporter, just add a query parameter `/prometheus?exporter=mysqld_exporter`
![Unbenannt](https://github.com/it-novum/openitcockpit-agent-go/assets/9019992/93ae4b72-a773-4aa6-ae19-10de1b25ab74)

If the Agent is using AutoTLS (default) the `/prometheus` endpoint is encrypted and will also require a TLS certificate for authentication. So everything is secure by default.

The exporter configuration in openITCOCKPIT is pretty straightforward

![Unbenannt](https://github.com/it-novum/openitcockpit-agent-go/assets/9019992/4d750508-e19a-4b61-9f5d-63657d427996)


```YML
params:
    exporter: [mysqld_exporter]
scheme: https
tls_config:
    insecure_skip_verify: true
    ca_file: /opt/openitc/agent/server_ca.pem
    cert_file: /opt/openitc/agent/server_ca.pem
    key_file: /opt/openitc/agent/server_ca.key
```

Currently only Pull Mode is supported, but I think this could also be implemented into the Push Mode.